### PR TITLE
add vnc viewer & proxy for websockify

### DIFF
--- a/web/components/vnc-viewer.tsx
+++ b/web/components/vnc-viewer.tsx
@@ -1,0 +1,98 @@
+import { VncScreen } from 'react-vnc';
+import { useRef, useEffect, useState, CSSProperties } from 'react';
+
+const defaultStyles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+  } as CSSProperties,
+  screen: {
+    width: '75vw',
+    height: '75vh',
+  } as CSSProperties,
+  error: {
+    padding: '1rem',
+    color: '#dc2626',
+    backgroundColor: '#fef2f2',
+    borderRadius: '0.5rem',
+  } as CSSProperties,
+  loading: {
+    padding: '1rem',
+    color: '#4b5563',
+  } as CSSProperties,
+};
+
+interface VNCViewerProps {
+  serviceUrl: string;
+  styles?: {
+    container?: CSSProperties;
+    screen?: CSSProperties;
+    error?: CSSProperties;
+    loading?: CSSProperties;
+  };
+}
+
+const isValidServiceUrl = (url: string): boolean => {
+  // Basic validation for k8s service URL format
+  const k8sServicePattern = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\.svc\.cluster\.local$/;
+  return k8sServicePattern.test(url);
+};
+
+const VNCViewer: React.FC<VNCViewerProps> = ({
+  serviceUrl,
+  styles = {},
+}) => {
+  const ref = useRef();
+  const [error, setError] = useState<string | null>(null);
+  const [wsUrl, setWsUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!serviceUrl) {
+      setError('Service URL is required');
+      return;
+    }
+
+    if (!isValidServiceUrl(serviceUrl)) {
+      setError('Invalid service URL format. Expected format: service-name.namespace.svc.cluster.local');
+      return;
+    }
+
+    setError(null);
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    setWsUrl(`${protocol}//${window.location.host}/${serviceUrl}/websockify`);
+  }, [serviceUrl]);
+
+  if (error) {
+    return (
+      <div style={{ ...defaultStyles.container, ...defaultStyles.error, ...styles.container, ...styles.error }}>
+        <p className="font-medium">Error:</p>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  if (!wsUrl) {
+    return (
+      <div style={{ ...defaultStyles.container, ...defaultStyles.loading, ...styles.container, ...styles.loading }}>
+        Validating connection...
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ ...defaultStyles.container, ...styles.container }}>
+      <VncScreen
+        url={wsUrl}
+        scaleViewport
+        background="#000000"
+        style={{ ...defaultStyles.screen, ...styles.screen }}
+        ref={ref as any}
+      />
+    </div>
+  );
+};
+
+export default VNCViewer;

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -12,6 +12,14 @@ const nextConfig: NextConfig = {
     ],
   },
   output: 'standalone',
+  rewrites: async () => {
+    return [
+      {
+        source: '/:host*/websockify',
+        destination: 'http://:host*:6080/websockify',
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -77,6 +77,7 @@
     "react-dom": "19.0.0-rc-45804af1-20241021",
     "react-markdown": "^9.0.1",
     "react-resizable-panels": "^2.1.7",
+    "react-vnc": "^3.0.7",
     "remark-gfm": "^4.0.0",
     "server-only": "^0.0.1",
     "sonner": "^1.5.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       react-resizable-panels:
         specifier: ^2.1.7
         version: 2.1.7(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)
+      react-vnc:
+        specifier: ^3.0.7
+        version: 3.0.7(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.1
@@ -1147,6 +1150,9 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@novnc/novnc@1.6.0':
+    resolution: {integrity: sha512-CJrmdSe9Yt2ZbLsJpVFoVkEu0KICEvnr3njW25Nz0jodaiFJtg8AYLGZogRYy0/N5HUWkGUsCmegKXYBSqwygw==}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -1602,6 +1608,9 @@ packages:
 
   '@types/node@22.13.10':
     resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
+
+  '@types/novnc__novnc@1.5.0':
+    resolution: {integrity: sha512-9DrDJK1hUT6Cbp4t03IsU/DsR6ndnIrDgZVrzITvspldHQ7n81F3wUDfq89zmPM3wg4GErH11IQa0QuTgLMf+w==}
 
   '@types/papaparse@5.3.15':
     resolution: {integrity: sha512-JHe6vF6x/8Z85nCX4yFdDslN11d+1pr12E526X8WAfhadOeaOTx5AuIkvDKIBopfvlzpzkdMx4YyvSKCM9oqtw==}
@@ -3417,6 +3426,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-vnc@3.0.7:
+    resolution: {integrity: sha512-G/KHuyzCaK4vVbMMub4hlz4Ama54gsU7V0KUnCzwgJMWAoedJ1B7k3mMxtbKQ4PpompKv4L3DOB2KnaTSWwZ0w==}
+    peerDependencies:
+      react: '>=19.0.0'
+      react-dom: '>=19.0.0'
+
   react@19.0.0-rc-45804af1-20241021:
     resolution: {integrity: sha512-RYkYXmX7Iia56DQJaNK0Ribh5uF/sDBNirtNNHNNqqa3wpIlcFOkRvPTW3RSwAXmBVnEZlKbeaMhlBT9p52lqA==}
     engines: {node: '>=0.10.0'}
@@ -4570,6 +4585,8 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@novnc/novnc@1.6.0': {}
+
   '@opentelemetry/api@1.9.0': {}
 
   '@panva/hkdf@1.2.1': {}
@@ -5016,6 +5033,8 @@ snapshots:
   '@types/node@22.13.10':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/novnc__novnc@1.5.0': {}
 
   '@types/papaparse@5.3.15':
     dependencies:
@@ -7218,6 +7237,13 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.18
+
+  react-vnc@3.0.7(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021):
+    dependencies:
+      '@novnc/novnc': 1.6.0
+      '@types/novnc__novnc': 1.5.0
+      react: 19.0.0-rc-45804af1-20241021
+      react-dom: 19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021)
 
   react@19.0.0-rc-45804af1-20241021: {}
 


### PR DESCRIPTION
## Add VNC WebSocket Proxy and Viewer Component

- Added WebSocket proxy support in `next.config.ts` to handle VNC connections on port 6080
- Added new `VNCViewer` component with service URL validation and configurable styles

This closes #26 